### PR TITLE
Assignment tabs and calendar schedule in Profile page

### DIFF
--- a/app/schedule/role/[role1]/page.tsx
+++ b/app/schedule/role/[role1]/page.tsx
@@ -9,7 +9,7 @@ export default function ScheduleByRole({params}: {params: {role1: string}}) {
 
   return (
     <Fragment>
-      <div className='flex flex-col gap-3 px-2 lg:px-0'>
+      <div className='flex flex-col gap-3 lg:px-0'>
         { columns.map((column, index) => (
           <div key={index} className="flex flex-col lg:flex-row gap-3 justify-center">
             { column.map((role, idx) => (

--- a/app/schedule/role/layout.tsx
+++ b/app/schedule/role/layout.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-
 import CCAddRow from '@/components/client/CCAddRow';
 import GCLoading from '@/components/global/GCLoading';
+import { useDevice } from '@/context/DeviceProvider';
 import { LockScrollProvider } from '@/context/LockScrollProvider';
 import { roleFilter } from '@/utils/constants';
 import Link from 'next/link';
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { Fragment, useState } from 'react';
 import { FiLock, FiUnlock } from 'react-icons/fi';
 
@@ -14,6 +14,8 @@ export default function RootLayout(props: Readonly<{
   children: React.ReactNode;
 }>) {
   const params = useParams<{role1: string}>();
+  const router = useRouter();
+    const { isMobile } = useDevice();
   const [isLoading, setIsLoading] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
 
@@ -22,7 +24,8 @@ export default function RootLayout(props: Readonly<{
     <Fragment>
       <div className='flex items-end justify-between gap-2 lg:gap-8 mt-12'>
         <div className='flex items-center flex-wrap gap-2'>
-          { roleFilter.map((role, index) => (
+          { !isMobile ? (
+            roleFilter.map((role, index) => (
               <Link
                 key={index}
                 href={role.href}
@@ -35,7 +38,24 @@ export default function RootLayout(props: Readonly<{
               >
                 {role.label}
               </Link>
-          ))}
+            ))) : (
+              <select
+                id='roles'
+                value={params.role1}
+                onChange={(e) => router.push(e.target.value)}
+                className='bg-slate-100 border border-slate-200 text-slate-600 px-2 py-1 mb-100 rounded-md focus:outline-none'
+              >
+                { roleFilter.map((role, index) => (
+                  <option
+                    key={index}
+                    value={role.value}
+                  >
+                    {role.label}
+                  </option>
+                ))}
+              </select>
+            )
+          }
         </div>
         { params?.role1 &&
           <div className='flex gap-2 items-center justify-center'>

--- a/components/client/CCAddRow.tsx
+++ b/components/client/CCAddRow.tsx
@@ -26,7 +26,7 @@ export default function CCAddRow({toggleLoading}: {toggleLoading: () => void}) {
   return (
   <button
     onClick={createMonthSchedule}
-    className="text-white px-2 py-1 bg-slate-700 rounded-md whitespace-nowrap"
+    className="text-white px-2.5 py-0.5 bg-slate-700 rounded-md whitespace-nowrap"
   >
     Add Date Rows
   </button>

--- a/components/client/CCCalendarSchedule.tsx
+++ b/components/client/CCCalendarSchedule.tsx
@@ -154,7 +154,7 @@ export default function CpCalendarSchedule({ events, length }: { events: any, le
                 </h3>
                 <div className="space-y-2">
                   {groupedEvents[dateKey].map((event: any, i: number) => (
-                    <div key={i} className={`${formatDayShort(dateKey) === "SAT" ? "border-sky-700" : "border-green-700" } border-l-4 pl-3 py-2 bg-sky-50 rounded`}>
+                    <div key={i} className={`${formatDayShort(dateKey) === "SAT" ? "border-sky-700 bg-sky-50" : "border-green-700 bg-green-50" } border-l-4 pl-3 py-2 rounded`}>
                       <div className="font-medium text-sm">{event.title}</div>
                       <div className="text-xs text-gray-600 mt-1">
                         {moment(event.start).format('h:mm A')}


### PR DESCRIPTION
- Assignment tabs are converted to dropdown on mobile view
- Calendar schedule is put to green bg to be uniform with green border
- Removed padding on assignment page table
- Update "Add Date Rows" UI to fit with dropdown or tab height of assignment roles